### PR TITLE
MvxBindingAttributes.xml : Renaming "GroupItemTemplate" android attri…

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Binding.Droid/Resources/values/MvxBindingAttributes.xml
+++ b/Cirrious/Cirrious.MvvmCross.Binding.Droid/Resources/values/MvxBindingAttributes.xml
@@ -12,7 +12,7 @@
     <attr name="MvxDropDownItemTemplate" format="string"/>
   </declare-styleable>
   <declare-styleable name="MvxExpandableListView">
-    <attr name="GroupItemTemplate" format="string"/>
+    <attr name="MvxGroupItemTemplate" format="string"/>
   </declare-styleable>
   <item type="id" name="MvxBindingTagUnique"/>
   <declare-styleable name="MvxImageView">


### PR DESCRIPTION
…bute to "MvxGroupItemTemplate"

"GroupItemTemplate" android attribute has been renamed to "MvxGroupItemTemplate" to match the current naming convention that uses "Mvx" prefix for android attribute.
